### PR TITLE
Ignore syslog on Windows environment

### DIFF
--- a/log/syslog.go
+++ b/log/syslog.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package log
 
 // Copyright 2014 Yieldr


### PR DESCRIPTION
syslog is *NIX specific, so it is better to support excluding it by conditinal build for windows.
